### PR TITLE
Removed broken check_error on libssh2_sftp_seek64

### DIFF
--- a/src/sftp/file.cr
+++ b/src/sftp/file.cr
@@ -12,8 +12,7 @@ module SSH2::SFTP
     end
 
     def seek(offset)
-      ret = LibSSH2.sftp_seek(self, offset.to_u64)
-      check_error(ret)
+      LibSSH2.sftp_seek(self, offset.to_u64)
     end
 
     def rewind


### PR DESCRIPTION
Since `lissh2_sftp_seek64` returns void/nil, it can't be compared in `check_error`, and it should catch the error when you try to read from or write to the handle anyway.