### PR TITLE
Compatibility with crystal 0.27.0

### DIFF
--- a/spec/ssh2_spec.cr
+++ b/spec/ssh2_spec.cr
@@ -22,7 +22,7 @@ describe SSH2 do
   end
 
   it "should be able to scp transfer file" do
-    fn = "#{Time.now.epoch}.txt"
+    fn = "#{Time.now.to_unix}.txt"
     connect_ssh do |session|
       session.scp_send(fn, 0o0644, 12) do |ch|
         ch.puts "hello world"
@@ -101,7 +101,7 @@ describe SSH2::SFTP do
   it "should be able to upload a file" do
     connect_ssh do |ssh|
       ssh.sftp_session do |sftp|
-        fn = "#{Time.now.epoch}_upload.txt"
+        fn = "#{Time.now.to_unix}_upload.txt"
         file = sftp.open(fn, "wc", 0o644)
         file.puts "hello world!"
         attrs = file.fstat

--- a/src/session.cr
+++ b/src/session.cr
@@ -289,7 +289,7 @@ class SSH2::Session
 
   # Send a file to the remote host via SCP.
   # A new channel is passed to the block and closed afterwards.
-  def scp_send(path, mode, size, mtime = Time.now.epoch, atime = Time.now.epoch)
+  def scp_send(path, mode, size, mtime = Time.now.to_unix, atime = Time.now.to_unix)
     channel = scp_send(path, mode, size, mtime, atime)
     begin
       yield channel

--- a/src/sftp/attributes.cr
+++ b/src/sftp/attributes.cr
@@ -52,7 +52,7 @@ class SSH2::SFTP::Attributes
   end
 
   def atime
-    Time.epoch(@stat.atime.to_i32)
+    Time.unix(@stat.atime.to_i32)
   end
 
   def atime=(v : Time)


### PR DESCRIPTION
Hi @datanoise,

`ssh2` does not compilte in `crystal` `0.27.0`, `epoch` has been renamed
https://github.com/crystal-lang/crystal/pull/6662

Regards,